### PR TITLE
Fix a bug in load_superpoint if there's no rgb in the point cloud

### DIFF
--- a/learning/spg.py
+++ b/learning/spg.py
@@ -213,12 +213,26 @@ def load_superpoint(args, fname, id, train, test_seed_offset):
 
     if args.pc_attribs != '':
         columns = []
-        if 'xyz' in args.pc_attribs: columns.append(P[:,:3])
-        if 'rgb' in args.pc_attribs: columns.append(P[:,3:6])
-        if 'e' in args.pc_attribs: columns.append(P[:,6,None])
-        if 'lpsv' in args.pc_attribs: columns.append(P[:,7:11])
-        if 'XYZ' in args.pc_attribs: columns.append(P[:,11:14])
-        if 'd' in args.pc_attribs: columns.append(P[:,14])
+
+        index=0
+        if 'xyz' in args.pc_attribs: 
+            columns.append(P[:,index:index+3])
+            index=index+3
+        if 'rgb' in args.pc_attribs: 
+            columns.append(P[:,index:index+3])
+            index=index+3
+        if 'e' in args.pc_attribs: 
+            columns.append(P[:,index,None])
+            index=index+1
+        if 'lpsv' in args.pc_attribs: 
+            columns.append(P[:,index:index+4])
+            index=index+4
+        if 'XYZ' in args.pc_attribs: 
+            columns.append(P[:,index:index+3])
+            index=index+3
+        if 'd' in args.pc_attribs: 
+            columns.append(P[:,index])
+
         P = np.concatenate(columns, axis=1)
 
     if train:


### PR DESCRIPTION
Here's the error:
RuntimeError: Given groups=1, weight of size 64 8 1, expected input[923, 5, 128] to have 8 channels, but got 5 channels instead

I set rgb=[] while pruning and --pc_attrib xyzelpsv while training, but the channels were not correct while doing the convolution(in the first convolution layer). There should be 8 channels(for there were 8 features), but instead there were only 5. 

That's because the codes didn't read the superpoints correctly in spg.py with load_superpoint.